### PR TITLE
Update slack_controller.rb

### DIFF
--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -5,7 +5,7 @@ require_relative '../services/initiative.rb'
 post '/roll' do
   type = params['text']&.upcase
 
-  if ['SOLO', 'TEAM'].include?(type)
+  if ['SOLO', 'GROUP'].include?(type)
     response = {
       response_type: 'in_channel',
       text: Initiative.roll(type)


### PR DESCRIPTION
Fix a bug in the type validation. "GROUP" is now valid instead of "TEAM".